### PR TITLE
fix: package sync fixes surfaced by first post-audit apply

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_10-install-arch-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_10-install-arch-packages.sh.tmpl
@@ -19,6 +19,8 @@ if [ -n "$missing" ]; then
   echo "arch packages: not available, skipped:" $missing >&2
 fi
 
+# -Syu: refresh databases and upgrade together — installing with a stale DB
+# 404s once mirrors rotate packages, and -Sy alone risks partial upgrades
 # shellcheck disable=SC2086
-yay -Sq --noconfirm --needed $packages
+yay -Syuq --noconfirm --needed $packages
 {{ end -}}

--- a/home/packages/Yayfile
+++ b/home/packages/Yayfile
@@ -24,7 +24,7 @@ git-lfs
 cronie
 gnupg
 jq
-p7zip
+7zip
 reflector
 shellcheck
 shfmt
@@ -35,7 +35,7 @@ asciinema
 aria2
 bat
 cli-visualizer
-doggo-bin
+doggo
 eza
 fastfetch
 fd


### PR DESCRIPTION
## Summary

Two fixes for failures hit on the first `chezmoi apply` after #173:

1. **Renamed Arch packages** — `p7zip` → `7zip`, `doggo-bin` → `doggo` (now in extra). The sync script's intersect-with-available logic silently skipped both; same failure mode that hid the compton→picom rename for years.
2. **Stale-database 404s** — `yay -S` against an old sync DB 404s once mirrors rotate a release (hit with shellcheck-0.11.0-75). The script now runs `yay -Syu` so databases refresh and the system upgrades atomically, which also avoids partial-upgrade risk.

## Test notes

- `doggo-bin` was removed locally to clear the conflict; merged Yayfile installs `doggo` cleanly
- `yay -Syu` run manually confirmed the 404s were stale-DB, not mirror breakage