### PR TITLE
feat: add f zfunc, the yazi cwd wrapper

### DIFF
--- a/home/dot_aliases
+++ b/home/dot_aliases
@@ -11,7 +11,7 @@ alias mkdir='mkdir -p -v'
 alias a='sgpt'
 alias b='bat'
 alias c='cursor'
-# alias f - reserved for yazi wrapper in .zfuncs
+# f: yazi wrapper (autoloaded from .zfuncs/f) — cds to yazi's exit directory
 alias g='git'
 alias l='eza --icons --group-directories-first'
 alias m='mkdir'

--- a/home/dot_zfuncs/f
+++ b/home/dot_zfuncs/f
@@ -1,0 +1,11 @@
+# f — yazi wrapper: cd the parent shell to yazi's last directory on quit
+local tmp cwd
+tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+
+yazi "$@" --cwd-file="$tmp"
+
+if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+  cd -- "$cwd"
+fi
+
+rm -f -- "$tmp"


### PR DESCRIPTION
## Summary

Adds the long-reserved `f` — yazi's standard cwd-file wrapper as an autoloaded zfunc. Browse with yazi, quit, and the shell lands in the directory you navigated to.

- `home/dot_zfuncs/f` — function body (autoload style, picked up by the existing `.zshrc` zfuncs loop, which #173 already null-globbed for safety)
- `.aliases` comment updated from "reserved" to pointing at the implementation

## Verification

Simulated the `.zshrc` autoload path in a clean zsh: `autoload -Uz f` resolves, `f --help` runs yazi and exits without a spurious `cd`.