### PR TITLE
chore: seed AGENTS.md, CLAUDE.md pointer, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+
+<!--
+Lead paragraph: ≤2 sentences, what changed and why. Then bullets:
+one line each, no **bold-label:** prefixes, no semicolon chains.
+Cover decisions, deviations, and tradeoffs — not a diff inventory;
+if the diff shows it plainly, don't restate it. Whole section ≤150
+words. No narrative about prior attempts or review cycles.
+-->
+
+## Testing
+
+- [ ] `chezmoi diff --source .worktrees/<branch>` shows only the expected changes
+- [ ] Rendered shell files pass `zsh -n`
+
+## Context
+
+<!--
+Only what the diff can't show (external constraints, follow-up plans).
+Delete this section by default.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Guidelines
+
+## Operations
+
+- Perform all work on a branch in a git worktree under `.worktrees/` (e.g.
+  `git worktree add .worktrees/<branch> -b <branch>`) — never commit directly on `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
+- When the work is ready, open a PR against `main` using the PR template
+  (`.github/PULL_REQUEST_TEMPLATE.md`).
+- PR descriptions are condensed by default: lead paragraph ≤2 sentences, one-line bullets, ≤150
+  words. Write the short version first — do not draft long and trim.
+- After pushing, link the opened PR's URL in your response so it's one click away.
+
+## This repo
+
+- chezmoi source state lives in `home/` (see `.chezmoiroot`); targets map via chezmoi naming
+  (`dot_`, `private_`, `executable_`, `encrypted_`, `.tmpl`). The repo root is a normal project.
+- `home/packages/` (Yayfile, Brewfile) is consumed by `home/.chezmoiscripts/`; package sync
+  re-runs when a manifest changes. The Yayfile sync intersects with available packages and
+  silently skips misses — check its "not available, skipped" stderr when a package seems absent.
+- Verify with `chezmoi diff --source <worktree>` (renders templates against real machine data)
+  and `zsh -n` on rendered shell files. `chezmoi apply` happens after merge, by the user.
+- Never run sudo-requiring commands from the agent shell — there is no TTY for the password
+  prompt, and each failure counts toward pam_faillock (3 failures = 10-minute account lockout).
+  Hand the exact command to the user instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md for project guidelines.


### PR DESCRIPTION
## Description

Seeds agent operating instructions, ported from the tools repo and cut to the portable parts, plus a dotfiles-specific section.

- Operations: worktrees under `.worktrees/`, conventional commits, condensed PRs
- Repo notes: chezmoi layout, Yayfile silent-skip gotcha, verification via `chezmoi diff --source` + `zsh -n`, no sudo from agent shells (faillock)
- `CLAUDE.md` is a one-line pointer at `AGENTS.md`
- PR template yoinked with the Testing checklist adapted to chezmoi

## Testing

- [x] `chezmoi diff --source .worktrees/<branch>` shows only the expected changes (none — root files never deploy under `.chezmoiroot home`)
- [x] Rendered shell files pass `zsh -n` (n/a, no shell changes)