### PR TITLE
feat: capture work-machine setup for chezmoi migration

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,9 +1,10 @@
 {{- $email := promptStringOnce . "email" "Git email" "me@geoffwhatley.com" -}}
 {{- $gui := promptBoolOnce . "gui" "Has a GUI/desktop session" -}}
 
-{{- /* detect WSL via the kernel release string (kernel data is linux-only) */ -}}
+{{- /* detect WSL via the kernel release string (on darwin .chezmoi.kernel
+       exists but has no osrelease key, so check for the key itself) */ -}}
 {{- $wsl := false -}}
-{{- if hasKey .chezmoi "kernel" -}}
+{{- if and (hasKey .chezmoi "kernel") (hasKey .chezmoi.kernel "osrelease") -}}
 {{-   $wsl = .chezmoi.kernel.osrelease | lower | contains "microsoft" -}}
 {{- end -}}
 

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -6,6 +6,8 @@ packages/**
 # terminal emulators need a display server
 .config/kitty
 .config/kitty/**
+.config/ghostty
+.config/ghostty/**
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}

--- a/home/dot_aliases.tmpl
+++ b/home/dot_aliases.tmpl
@@ -74,10 +74,14 @@ en() { awk '{printf "%s\\n", $0}' "$1"; }         # escapes newlines
 alias getclip="xclip -selection c -o"
 alias setclip="xclip -selection c"
 
+# zellij
+za() { zellij attach -c agents; }
+
 # cli
 alias shc="shellcheck"
 alias shfc="shfmt"
 alias wt='cd "$(wtpick)"'
+wtnb() { cd "$(command wtnb "$@")"; }
 {{ if eq .chezmoi.os "darwin" -}}
 alias wtc='cursor -n "$(wtpick)"'
 alias ca='cursor agent --model=gpt-5'

--- a/home/dot_config/btop/btop.conf
+++ b/home/dot_config/btop/btop.conf
@@ -53,14 +53,14 @@ graph_symbol_net = "default"
 graph_symbol_proc = "default"
 
 #* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
-shown_boxes = "proc"
+shown_boxes = "cpu proc mem"
 
 #* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
 update_ms = 2000
 
 #* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu direct",
 #* "cpu lazy" sorts top process over time (easier to follow), "cpu direct" updates top process directly.
-proc_sorting = "cpu lazy"
+proc_sorting = "cpu direct"
 
 #* Reverse sorting order, True or False.
 proc_reversed = false
@@ -75,7 +75,7 @@ proc_colors = true
 proc_gradient = true
 
 #* If process cpu usage should be of the core it's running on or usage of the total available cpu power.
-proc_per_core = false
+proc_per_core = true
 
 #* Show process memory as bytes instead of percent.
 proc_mem_bytes = true
@@ -199,7 +199,7 @@ disk_free_priv = false
 show_io_stat = true
 
 #* Toggles io mode for disks, showing big graphs for disk read/write speeds.
-io_mode = false
+io_mode = true
 
 #* Set to True to show combined read/write io graphs in io mode.
 io_graph_combined = false
@@ -217,7 +217,7 @@ net_upload = 100
 net_auto = true
 
 #* Sync the auto scaling for download and upload to whichever currently has the highest scale.
-net_sync = true
+net_sync = false
 
 #* Starts with the Network Interface specified here.
 net_iface = ""

--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -1,0 +1,113 @@
+# Ghostty config — ported from ~/.config/kitty/kitty.conf
+# Run `ghostty +show-config --default --docs` to see every option + docs.
+# Reload in-app: cmd+shift+, (or quit/relaunch).
+
+###############################################################################
+# theme / colors
+#
+# kitty.conf ends with `include current-theme.conf` (Catppuccin Mocha), which
+# overrides the blue color scheme at the top of kitty.conf. Mocha is what you
+# actually see, and Ghostty ships it built in. `ghostty +list-themes` to browse.
+###
+theme = Catppuccin Mocha
+
+# background_opacity 0.9
+background-opacity = 0.9
+# (kitty dynamic_background_opacity has no static equivalent; opacity is
+#  adjustable at runtime via a keybind instead. background-blur is off, like kitty.)
+
+###############################################################################
+# fonts
+###
+# Operator Mono is installed; family name is exactly "Operator Mono". Its
+# regular weight resolves to the "Book" face, and bold/italic styles (incl. the
+# signature cursive italics) auto-resolve from the same family, so kitty's four
+# *_font lines collapse to one. Pin a weight with e.g. `font-style = Light`.
+# List faces: `ghostty +list-fonts | grep -i operator`
+font-family = Operator Mono
+font-size = 14
+
+# Stop Ghostty faux-bolding/italicising (the "leaking"/smeared look). Use only
+# real faces from the family.
+font-synthetic-style = false
+# Match kitty's look: it renders everything in the Medium weight (uniform
+# semi-bold, readable). Ghostty defaulted regular -> thin Book + heavy Bold,
+# giving harsh contrast. Pin everything to Medium for the same uniform feel.
+# Want real bold contrast back? set font-style-bold = Bold (and -bold-italic = Bold Italic).
+font-style = Bold
+font-style-bold = Bold
+font-style-italic = Bold Italic
+font-style-bold-italic = Bold Italic
+
+# Prompt/powerline icons (p10k/purepower): Ghostty bundles a Nerd Font and
+# auto-falls-back for symbol glyphs, so icons should render with plain Operator
+# Mono. If any show as boxes, switch the line above to:
+#   font-family = OperatorMono Nerd Font Mono
+
+# kitty symbol_map: borrow these glyphs from Fira Code to dodge Operator/Dank
+# Mono ligature issues. Same codepoint list, Ghostty syntax.
+font-codepoint-map = U+4C,U+7B,U+5B,U+7C,U+23,U+21,U+3F,U+24,U+26,U+25,U+2A,U+2B,U+3D,U+2D,U+7E,U+2E,U+5F,U+3B,U+2F,U+5D,U+7D,U+3E=Fira Code
+
+###############################################################################
+# cursor
+#
+# cursor color / cursor_text_color come from the Catppuccin theme above.
+###
+cursor-style = underline
+cursor-style-blink = true
+# (kitty cursor_blink_interval 0.5 has no equivalent — Ghostty uses the system
+#  blink rate; cursor_stop_blinking_after has no equivalent either.)
+
+###############################################################################
+# mouse
+###
+copy-on-select = false
+focus-follows-mouse = false
+mouse-hide-while-typing = true
+# kitty wheel_scroll_multiplier 5.0
+mouse-scroll-multiplier = 5
+# (kitty select_by_word_characters / rectangle_select_modifiers: no equivalent.)
+
+###############################################################################
+# window
+###
+window-padding-x = 8
+window-padding-y = 8
+# hide_window_decorations yes -> hide the macOS titlebar (traffic lights still
+# appear on hover). Use `window-decoration = none` if you want zero chrome.
+macos-titlebar-style = hidden
+# remember_window_size no
+window-save-state = never
+macos-option-as-alt = true
+# (kitty initial_window_width/height are pixels; Ghostty window-width/height are
+#  in CELLS, so 1920x1080 doesn't port directly — set cell counts if you want.)
+
+###############################################################################
+# scrollback
+###
+# kitty scrollback_lines 2000. Ghostty scrollback-limit is in BYTES (default
+# ~10MB, far more than 2000 lines). Left at default; uncomment to shrink:
+# scrollback-limit = 5000000
+# (kitty scrollback_pager / less integration: no equivalent.)
+
+###############################################################################
+# keybindings
+#
+# kitty mapped cmd+1..4 / ctrl+shift+1..4 to first..fourth_window (splits).
+# Ghostty already binds super+1..9 to goto_tab by default, so cmd+1..4 work
+# out of the box for TABS. Ghostty has no goto-split-by-index; split focus is
+# directional. Uncomment to bind directional split nav:
+# keybind = ctrl+shift+h=goto_split:left
+# keybind = ctrl+shift+l=goto_split:right
+# keybind = ctrl+shift+k=goto_split:up
+# keybind = ctrl+shift+j=goto_split:down
+
+###############################################################################
+# not ported (no Ghostty equivalent)
+#
+# - default_session (splits layout launching btop etc.): Ghostty has no session
+#   file. Closest is a shell alias/script that opens splits, or window-save-state.
+# - term xterm-kitty: Ghostty sets TERM=xterm-ghostty automatically.
+# - box_drawing_scale, adjust_line_height/column_width: see adjust-* options.
+# - enable_audio_bell, tab_bar_style, etc.: macOS tabs are native; no audio bell.
+###

--- a/home/dot_config/private_gh/private_config.yml
+++ b/home/dot_config/private_gh/private_config.yml
@@ -13,6 +13,9 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
     co: pr checkout
+    prs: f -p
+    logs: f -l
+    runs: f -r
 # The path to a unix socket through which to send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.

--- a/home/dot_env.tmpl
+++ b/home/dot_env.tmpl
@@ -6,6 +6,8 @@ export CLICOLOR=1
 export FZF_DEFAULT_OPTS="--color=16"
 export FZF_DEFAULT_COMMAND="rg --files --no-ignore-vcs --hidden"
 
+export BEADS_DIR="$HOME/.beads-personal"
+
 export RIPGREP_CONFIG_PATH="$HOME/.config/ripgrep/config"
 
 export PATH="$HOME/.local/bin:$PATH"
@@ -21,3 +23,7 @@ export LANGUAGE="en_US.UTF-8"
 
 export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"
 {{- end }}
+
+if command -v gh >/dev/null; then
+  export GITHUB_TOKEN="$(gh auth token)"
+fi

--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -56,3 +56,7 @@
 [credential "https://gist.github.com"]
 	helper =
 	helper = !gh auth git-credential
+[rebase]
+  updateRefs = true
+[beads]
+  role = maintainer

--- a/home/dot_gitignore
+++ b/home/dot_gitignore
@@ -5,4 +5,9 @@ libs/*
 node_modules
 .undodir/
 
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+
 **/.claude/settings.local.json

--- a/home/dot_local/bin/executable_csql
+++ b/home/dot_local/bin/executable_csql
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+# csql — fzf picker for cloud-sql-proxy.
+# Lists Cloud SQL instances in the active (or chosen) GCP project, lets you
+# pick one with fzf, and runs cloud-sql-proxy against it. Extra args after `--`
+# pass through to cloud-sql-proxy.
+
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: csql [options] [-- proxy-args...]
+
+Options:
+  -p, --project <id>   GCP project to list instances from (skips the picker)
+  -A, --active         use gcloud's active project instead of fzf-picking one
+  -P, --pick-project   fzf-pick the project first (default)
+  -L, --port <port>    local port to bind (passes --port to cloud-sql-proxy)
+  -i, --iam            enable --auto-iam-authn
+      --private-ip     connect via private IP
+  -h, --help           show this help
+
+Anything after `--` is passed straight through to cloud-sql-proxy.
+
+Examples:
+  csql                              # pick project, then instance, default port
+  csql -L 5433                      # pick project + instance, bind on localhost:5433
+  csql -A                           # use active project, just pick an instance
+  csql -p my-proj -i                # specific project, IAM auth
+  csql -- --debug-logs              # passthrough flags
+EOF
+}
+
+PROJECT=""
+PICK_PROJECT=1
+PORT=""
+IAM=0
+PRIVATE_IP=0
+PASSTHROUGH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p|--project) PROJECT="${2:-}"; shift 2 ;;
+    -A|--active) PICK_PROJECT=0; shift ;;
+    -P|--pick-project) PICK_PROJECT=1; shift ;;
+    -L|--port) PORT="${2:-}"; shift 2 ;;
+    -i|--iam) IAM=1; shift ;;
+    --private-ip) PRIVATE_IP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; PASSTHROUGH="$*"; break ;;
+    *) printf 'csql: unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+command -v gcloud >/dev/null 2>&1 || { printf 'csql: gcloud not found in PATH\n' >&2; exit 127; }
+command -v cloud-sql-proxy >/dev/null 2>&1 || { printf 'csql: cloud-sql-proxy not found in PATH\n' >&2; exit 127; }
+command -v fzf >/dev/null 2>&1 || { printf 'csql: fzf not found in PATH\n' >&2; exit 127; }
+
+if [ "$PICK_PROJECT" -eq 1 ] && [ -z "$PROJECT" ]; then
+  PROJECT="$(
+    gcloud projects list --format='value(projectId,name)' 2>/dev/null \
+      | column -t -s "$(printf '\t')" \
+      | fzf --prompt='GCP project > ' --height=40% --reverse \
+      | awk '{print $1}'
+  )"
+  [ -z "$PROJECT" ] && { printf 'csql: no project selected\n' >&2; exit 1; }
+fi
+
+if [ -z "$PROJECT" ]; then
+  PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+fi
+[ -z "$PROJECT" ] && { printf 'csql: no project set; use -p <id> or drop -A to pick one\n' >&2; exit 1; }
+
+# Format: name, engine, region, connectionName — TSV for column alignment.
+INSTANCES="$(
+  gcloud sql instances list \
+    --project="$PROJECT" \
+    --format='value(name,databaseVersion,region,connectionName)' \
+    2>/dev/null
+)"
+[ -z "$INSTANCES" ] && { printf 'csql: no Cloud SQL instances in project %s\n' "$PROJECT" >&2; exit 1; }
+
+PICK="$(
+  printf '%s\n' "$INSTANCES" \
+    | column -t -s "$(printf '\t')" \
+    | fzf --prompt="Cloud SQL [$PROJECT] > " --height=40% --reverse
+)"
+[ -z "$PICK" ] && { printf 'csql: nothing selected\n' >&2; exit 1; }
+
+# Last column is the connection name (project:region:instance).
+CONN="$(printf '%s' "$PICK" | awk '{print $NF}')"
+NAME="$(printf '%s' "$PICK" | awk '{print $1}')"
+ENGINE="$(printf '%s' "$PICK" | awk '{print $2}')"
+
+set -- "$CONN"
+[ -n "$PORT" ] && set -- "$@" --port "$PORT"
+[ "$IAM" -eq 1 ] && set -- "$@" --auto-iam-authn
+[ "$PRIVATE_IP" -eq 1 ] && set -- "$@" --private-ip
+# shellcheck disable=SC2086
+[ -n "$PASSTHROUGH" ] && set -- "$@" $PASSTHROUGH
+
+printf 'csql: %s (%s) → cloud-sql-proxy %s\n' "$NAME" "$ENGINE" "$*" >&2
+exec cloud-sql-proxy "$@"

--- a/home/dot_local/bin/executable_wtnb
+++ b/home/dot_local/bin/executable_wtnb
@@ -3,22 +3,75 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: wtnb <branch-name>
+Usage: wtnb <branch-name> [--pointer <ref>] [--files <f1,f2,...>]
 
-Create a git worktree in a sibling directory:
-  <repo>.worktree.<branch-slug>
+Create a git worktree in the .worktrees/ subdirectory of the repo root:
+  <repo>/.worktrees/<branch-slug>
 
 - If the branch exists, a worktree is created for it.
-- If the branch does not exist, it is created from the current HEAD.
+- If the branch does not exist, it is created from --pointer (default: HEAD).
+- --files moves the listed files into the root of the new worktree.
 
-Example:
-  # from /projects/main-repo
+Options:
+  --pointer <ref>      Start point for a new branch (branch, tag, or commit).
+                       Only valid when creating a new branch.
+  --files <f1,f2,...>  Comma-separated files to move into the worktree root.
+
+(--pointer=<ref> and --files=<...> are also accepted.)
+
+Examples:
   wtnb feat/some-new-branch
-  # -> /projects/main-repo.worktree.feat-some-new-branch
+  # -> <repo>/.worktrees/feat-some-new-branch (forks current HEAD)
+
+  wtnb feat/blah --pointer main --files TICKET.md,notes.txt
+  # -> forks main, moves TICKET.md & notes.txt into the worktree
 EOF
 }
 
-branch="${1:-}"
+branch=""
+pointer=""
+files=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pointer=*)
+      pointer="${1#*=}"
+      shift
+      ;;
+    --pointer)
+      pointer="${2:-}"
+      shift 2
+      ;;
+    --files=*)
+      IFS=',' read -r -a files <<<"${1#*=}"
+      shift
+      ;;
+    --files)
+      IFS=',' read -r -a files <<<"${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$branch" ]]; then
+        branch="$1"
+        shift
+      else
+        echo "Unexpected argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
 if [[ -z "$branch" ]]; then
   usage >&2
   exit 1
@@ -30,13 +83,21 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-repo_root="$(git rev-parse --show-toplevel)"
+# --git-common-dir always resolves to the main repo's .git dir,
+# even when run from inside a worktree
+repo_root="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
 
 # turn "feat/some-new-branch" -> "feat-some-new-branch"
 branch_slug="$(printf '%s' "$branch" | tr '/:' '-')"
 
-# final path sits NEXT TO the repo, not inside it
-target_path="${repo_root}.worktree.${branch_slug}"
+# final path sits inside the repo's .worktrees/ directory
+target_path="${repo_root}/.worktrees/${branch_slug}"
+
+# ensure .worktrees dir exists and is gitignored
+mkdir -p "${repo_root}/.worktrees"
+if ! grep -qxF '.worktrees' "${repo_root}/.gitignore" 2>/dev/null; then
+  echo '.worktrees' >> "${repo_root}/.gitignore"
+fi
 
 if [[ -e "$target_path" ]]; then
   echo "Target path already exists: $target_path" >&2
@@ -45,15 +106,54 @@ fi
 
 # check if branch already exists
 if git rev-parse --verify --quiet "refs/heads/$branch" >/dev/null; then
-  echo "Branch '$branch' exists, creating worktree for it..."
-  git worktree add "$target_path" "$branch"
+  if [[ -n "$pointer" ]]; then
+    echo "Branch '$branch' already exists; --pointer only applies when creating a new branch." >&2
+    exit 1
+  fi
+  echo "Branch '$branch' exists, creating worktree for it..." >&2
+  git worktree add "$target_path" "$branch" >&2
 else
-  # create new branch from current HEAD
-  current_head="$(git rev-parse --abbrev-ref HEAD)"
-  echo "Branch '$branch' does not exist, creating from '$current_head'..."
-  git worktree add -b "$branch" "$target_path"
+  # create new branch from the pointer (defaults to current HEAD)
+  start_point="${pointer:-HEAD}"
+  if ! git rev-parse --verify --quiet "${start_point}^{commit}" >/dev/null; then
+    echo "Pointer '$start_point' is not a valid branch, tag, or commit." >&2
+    exit 1
+  fi
+  start_desc="$(git rev-parse --abbrev-ref "$start_point" 2>/dev/null || printf '%s' "$start_point")"
+  echo "Branch '$branch' does not exist, creating from '$start_desc'..." >&2
+  git worktree add -b "$branch" "$target_path" "$start_point" >&2
 fi
 
-echo "Created worktree:"
-echo "  branch: $branch"
-echo "  path:   $target_path"
+# copy Claude Code's gitignored local settings from the main repo so
+# permission allowlists carry into the new worktree (otherwise every
+# worktree starts fresh and re-prompts for the same approvals)
+if [[ -f "${repo_root}/.claude/settings.local.json" ]]; then
+  mkdir -p "${target_path}/.claude"
+  cp "${repo_root}/.claude/settings.local.json" "${target_path}/.claude/settings.local.json"
+  echo "Copied .claude/settings.local.json from main repo." >&2
+fi
+
+# install dependencies based on lock file
+if [[ -f "${target_path}/pnpm-lock.yaml" ]]; then
+  echo "Running pnpm install..." >&2
+  (cd "$target_path" && pnpm install) >&2
+elif [[ -f "${target_path}/yarn.lock" ]]; then
+  echo "Running yarn install..." >&2
+  (cd "$target_path" && yarn install) >&2
+elif [[ -f "${target_path}/package-lock.json" ]]; then
+  echo "Running npm install..." >&2
+  (cd "$target_path" && npm install) >&2
+fi
+
+# move optional files into the worktree root
+if [[ ${#files[@]} -gt 0 ]]; then
+  mv "${files[@]}" "$target_path" >&2
+  echo "Moved ${#files[@]} file(s) into worktree." >&2
+fi
+
+echo "Created worktree:" >&2
+echo "  branch: $branch" >&2
+echo "  path:   $target_path" >&2
+
+# print path to stdout for use by shell wrappers
+echo "$target_path"

--- a/home/dot_zfuncs/_wtnb
+++ b/home/dot_zfuncs/_wtnb
@@ -1,0 +1,32 @@
+#compdef wtnb
+
+# Completion for the `wtnb` worktree helper:
+#   wtnb <branch> [--pointer <ref>] [--files <f1,f2,...>]
+
+_wtnb() {
+  _arguments -C \
+    '--pointer[start point for a new branch (branch, tag, or commit)]:ref:__wtnb_refs' \
+    '--files[comma-separated files to move into the worktree]:files:_sequence _files' \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '1:branch name:__wtnb_local_branches' \
+    && return 0
+}
+
+# any ref is a valid start point: local heads, remotes, tags
+__wtnb_refs() {
+  local -a refs
+  refs=(${(f)"$(git for-each-ref --format='%(refname:short)' \
+    refs/heads refs/remotes refs/tags 2>/dev/null)"})
+  _describe -t refs 'git ref' refs
+}
+
+# the positional arg is usually a new branch name; offer existing local
+# heads as suggestions (worktree-for-existing-branch case) without restricting
+__wtnb_local_branches() {
+  local -a branches
+  branches=(${(f)"$(git for-each-ref --format='%(refname:short)' \
+    refs/heads 2>/dev/null)"})
+  _describe -t branches 'branch' branches
+}
+
+_wtnb "$@"

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -118,6 +118,13 @@ eval "$(zoxide init zsh)"
 source ~/.orbstack/shell/init.zsh 2>/dev/null || :
 
 export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
+
+# pnpm
+export PNPM_HOME="$HOME/Library/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
 {{- end }}
 
 ssh-add -l >/dev/null 2>&1 || ssh-add ~/.ssh/id

--- a/home/packages/Brewfile
+++ b/home/packages/Brewfile
@@ -23,12 +23,15 @@ cask 'raycast'
 # core software
 brew 'bat'
 brew 'btop'
+brew 'chezmoi'
+brew 'gnupg'
 brew 'eza'
 brew 'delta'
 brew 'doggo'
 brew 'fastfetch'
 brew 'fd'
 brew 'fzf'
+cask 'ghostty'
 cask 'kitty'
 brew 'pinentry-mac'
 brew 'procs'
@@ -63,6 +66,34 @@ cask 'arc'
 
 # password managers
 cask '1password'
+
+# work: cloud & infra
+brew 'awscli'
+brew 'aws-sam-cli'
+brew 'aws-vault'
+cask 'session-manager-plugin'
+cask 'gcloud-cli'
+brew 'cloud-sql-proxy'
+brew 'docker'
+brew 'kubernetes-cli'
+brew 'k9s'
+brew 'int128/kubelogin/kubelogin'
+brew 'pulumi'
+brew 'localstack/tap/localstack-cli'
+brew 'infisical/get-cli/infisical'
+
+# work: dev
+brew 'withgraphite/tap/graphite'
+brew 'shopify/shopify/shopify-cli'
+brew 'postgresql@16'
+brew 'lazygit'
+cask 'tableplus'
+cask 'bruno'
+
+# work: apps
+cask 'slack'
+cask 'karabiner-elements'
+cask 'caffeine'
 
 # misc
 cask 'obsidian'

--- a/home/packages/Brewfile
+++ b/home/packages/Brewfile
@@ -79,11 +79,9 @@ brew 'kubernetes-cli'
 brew 'k9s'
 brew 'int128/kubelogin/kubelogin'
 brew 'pulumi'
-brew 'localstack/tap/localstack-cli'
 brew 'infisical/get-cli/infisical'
 
 # work: dev
-brew 'withgraphite/tap/graphite'
 brew 'shopify/shopify/shopify-cli'
 brew 'postgresql@16'
 brew 'lazygit'
@@ -92,7 +90,6 @@ cask 'bruno'
 
 # work: apps
 cask 'slack'
-cask 'karabiner-elements'
 cask 'caffeine'
 
 # misc


### PR DESCRIPTION
## Description

Ports everything the work machine's yadm checkout (branch `pipelabs-macos` plus uncommitted changes) had that the chezmoi rebuild lacked, ahead of migrating that machine to chezmoi.

- Fixes `.chezmoi.toml.tmpl` crashing on macOS (`.chezmoi.kernel` exists there but has no `osrelease` key)
- Syncs the newer `wtnb` (`.worktrees/` layout, `--pointer`/`--files`) and adds its zsh completion plus `csql` (Cloud SQL proxy fzf picker)
- Ports shell tweaks: `BEADS_DIR`, `GITHUB_TOKEN` via `gh auth token`, pnpm PATH, `za` zellij session, `wtnb` cd wrapper, `rebase.updateRefs`, `[beads]` git config, beads/dolt global ignores, btop prefs, `gh f` aliases
- Adds ghostty config (gui-gated like kitty) and the work brew toolchain (AWS, gcloud, k8s, pulumi, shopify, postgres, slack, etc.)
- `za` now uses `zellij attach -c agents`: the old layout file (`~/projects/layouts/agents.kdl`) no longer exists

## Testing

- [x] `chezmoi diff --source .worktrees/feat/work-machine-sync` shows only the expected changes
- [x] Rendered shell files pass `zsh -n`; `csql`/`wtnb` pass `sh -n`/`bash -n`; Brewfile parses via `brew bundle list`
