### PR TITLE
fix(packages): firefox-developer-edition cask renamed upstream

### DIFF
--- a/home/packages/Brewfile
+++ b/home/packages/Brewfile
@@ -60,7 +60,7 @@ brew 'tree-sitter-cli'
 
 # browsers
 cask 'firefox'
-cask 'firefox-developer-edition'
+cask 'firefox@developer-edition'
 cask 'google-chrome'
 cask 'arc'
 


### PR DESCRIPTION
## Description

`brew bundle` fails with `No available formula with the name "firefox-developer-edition"`: homebrew renamed the cask to `firefox@developer-edition`. Broke the first post-migration `chezmoi apply` on the work mac.

## Testing

- [x] `brew info --cask firefox@developer-edition` resolves (153.0b8)
- [x] Every other Brewfile entry checked against `brew info`; no other stale names