### PR TITLE
fix(packages): auto-trust third-party taps before brew bundle

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_11-install-darwin-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_11-install-darwin-packages.sh.tmpl
@@ -15,5 +15,11 @@ if ! command -v brew >/dev/null; then
   done
 fi
 
+# brew refuses formulae from untrusted third-party taps; listing a tap-scoped
+# formula in the Brewfile is our explicit trust decision, so trust those taps
+grep -Eo "^brew .([^']+)/[^'/]+'" "{{ .chezmoi.sourceDir }}/packages/Brewfile" \
+  | sed -E "s|^brew .||; s|/[^/]+.$||" | sort -u \
+  | while read -r tap; do brew trust "$tap" >/dev/null; done
+
 brew bundle --file "{{ .chezmoi.sourceDir }}/packages/Brewfile"
 {{ end -}}


### PR DESCRIPTION
## Description

Brew now refuses to load formulae from untrusted taps, so `brew bundle` hard-fails on `kubelogin`/`infisical`/`shopify-cli`. The packages script now extracts tap-scoped formulae from the Brewfile and runs `brew trust` on each tap first. Listing a tap-scoped formula in the Brewfile is the explicit trust decision, so this automates only what's already opted into.

## Testing

- [x] Tap extraction against the real Brewfile yields exactly `infisical/get-cli`, `int128/kubelogin`, `shopify/shopify`
- [x] Rendered script passes `bash -n`