### PR TITLE
feat: add zed launcher for windows-hosted zed on wsl

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -25,3 +25,8 @@ packages/**
 .config/yay
 .config/yay/**
 {{ end }}
+
+{{ if not .wsl }}
+# launches the Windows-hosted Zed; meaningless outside WSL
+.local/bin/zed
+{{ end }}

--- a/home/dot_local/bin/executable_zed
+++ b/home/dot_local/bin/executable_zed
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Launch the Windows-hosted Zed against this WSL distro. Delegates to the
+# launcher Zed ships beside zed.exe, which enables native WSL remoting
+# (zed.exe --wsl user@distro), so plain Linux paths work and language servers
+# run inside the distro. Exists so `zed` keeps working when Windows PATH
+# interop is disabled or ordered after ~/.local/bin.
+# Deployed only on WSL via .chezmoiignore.
+
+set -eu
+
+zed() {
+  launcher=$(find /mnt/c/Users/*/AppData/Local/Programs/Zed/bin \
+    -maxdepth 1 -iname zed -type f -print -quit 2>/dev/null)
+
+  if [ -z "$launcher" ]; then
+    echo 'zed: no Windows Zed launcher under /mnt/c/Users/*/AppData/Local/Programs/Zed/bin' >&2
+    exit 1
+  fi
+
+  exec "$launcher" "$@"
+}
+
+zed "$@"


### PR DESCRIPTION
## Description

Adds a `zed` script to `.local/bin` that opens files from WSL in the Windows-hosted Zed. It delegates to the launcher Zed ships beside `zed.exe`, which uses native WSL remoting (`zed.exe --wsl user@distro`) — plain Linux paths, language servers inside the distro.

- Discovery is a case-insensitive find under `/mnt/c/Users/*/AppData/Local/Programs/Zed/bin` (the exe is `Zed.exe`; drvfs lookups hide the case).
- The script exists so `zed` works even with Windows PATH interop disabled or ordered late.
- Ignored on non-WSL machines via the existing `.wsl` template var in `.chezmoiignore`.

## Testing

- [x] `chezmoi diff --source .worktrees/feat/zed-wsl-launcher` shows only the expected changes
- [x] Rendered shell files pass `zsh -n`