### PR TITLE
feat(nvim): add octo.nvim for GitHub PR review

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -372,6 +372,7 @@ do
       { '<leader>s', group = '[S]earch', mode = { 'n', 'v' } },
       { '<leader>t', group = '[T]oggle' },
       { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } }, -- Enable gitsigns recommended keymaps first
+      { '<leader>o', group = '[O]cto PRs' },
       { 'gr', group = 'LSP Actions', mode = { 'n' } },
       { 'gs', group = '[S]urround', mode = { 'n', 'v' } },
     },
@@ -1038,6 +1039,28 @@ do
       end
     end,
   })
+end
+
+-- ============================================================
+-- SECTION 9b: GITHUB PR REVIEW
+-- octo.nvim — PR diffs, inline comments, reviews via gh
+-- ============================================================
+do
+  -- Octo drives the GitHub PR lifecycle from inside Neovim through the `gh`
+  -- CLI (must be authenticated — check with `gh auth status`): browse and
+  -- checkout PRs, review diffs file-by-file, leave inline comments and
+  -- suggestions, mark files viewed, and submit the review.
+  --
+  -- Entry points: `:Octo pr list`, `:Octo review` on a checked-out PR branch,
+  -- or `:Octo` alone for the command picker. In-review mappings live under
+  -- <localleader> — see `:help octo-config-mappings`.
+  vim.pack.add { gh 'pwntester/octo.nvim' }
+  require('octo').setup {
+    picker = 'telescope',
+    enable_builtin = true, -- bare `:Octo` opens the command picker
+  }
+  vim.keymap.set('n', '<leader>op', '<cmd>Octo pr list<CR>', { desc = '[O]cto [P]R list' })
+  vim.keymap.set('n', '<leader>or', '<cmd>Octo review<CR>', { desc = '[O]cto [R]eview PR' })
 end
 
 -- ============================================================

--- a/home/dot_config/nvim/nvim-pack-lock.json
+++ b/home/dot_config/nvim/nvim-pack-lock.json
@@ -94,6 +94,10 @@
     "zen-mode.nvim": {
       "rev": "8564ce6d29ec7554eb9df578efa882d33b3c23a7",
       "src": "https://github.com/folke/zen-mode.nvim"
+    },
+    "octo.nvim": {
+      "rev": "b9a73e167f851a98d8f29d62658d3640bb8a7314",
+      "src": "https://github.com/pwntester/octo.nvim"
     }
   }
 }


### PR DESCRIPTION
## Description

Adds octo.nvim so PR review happens in real nvim buffers instead of GitHub's laggy files-changed page — diffs with native highlighting, inline comments/suggestions, per-file viewed state, and review submission through the `gh` CLI.

- Uses the already-installed telescope as picker; no new dependencies beyond octo itself
- `enable_builtin` so bare `:Octo` opens a command picker
- `<leader>op` PR list, `<leader>or` start review; which-key group added
- Lockfile pins octo at the rev verified below

## Testing

- [x] `chezmoi diff --source .worktrees/feat-octo` shows only the expected changes
- [x] Rendered shell files pass `zsh -n` (n/a — lua; full config booted headless in a sandboxed XDG env: clean install, `require('octo')` ok, `:Octo` registered)