### PR TITLE
fix(nvim): enable have_nerd_font, unbreaking octo review

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -98,8 +98,11 @@ do
   vim.g.mapleader = ' '
   vim.g.maplocalleader = ' '
 
-  -- Set to true if you have a Nerd Font installed and selected in the terminal
-  vim.g.have_nerd_font = false
+  -- Set to true if you have a Nerd Font installed and selected in the terminal.
+  -- True here: kitty runs OperatorMono Nerd Font and ghostty falls back to its
+  -- bundled Nerd Font for glyphs Operator Mono lacks. This also gates the
+  -- mini.icons nvim-web-devicons mock that octo.nvim's file panel requires.
+  vim.g.have_nerd_font = true
 
   -- [[ Setting options ]]
   --  See `:help vim.o`


### PR DESCRIPTION
## Description

`:Octo review` crashed with `module 'nvim-web-devicons' not found` — the mini.icons devicons mock is gated behind `vim.g.have_nerd_font`, which was still the stale kickstart default of `false`. Both terminals do render nerd glyphs (kitty: OperatorMono Nerd Font; ghostty: bundled Nerd Font fallback), so flip it to `true`.

- Also lights up the icons already wired to the flag in which-key, mini.statusline, and telescope
- Comment on the flag now records why it's true and what depends on it

## Testing

- [x] `chezmoi diff --source .worktrees/fix-nerd-font` shows only the expected changes
- [x] Rendered shell files pass `zsh -n` (n/a — lua; sandboxed headless boot: `require('nvim-web-devicons')` resolves via the mock and octo's renderer loads past the previously-failing line)