### PR TITLE
feat(nvim): octo panel 'o' opens diff without leaving panel

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -1064,6 +1064,25 @@ do
   }
   vim.keymap.set('n', '<leader>op', '<cmd>Octo pr list<CR>', { desc = '[O]cto [P]R list' })
   vim.keymap.set('n', '<leader>or', '<cmd>Octo review<CR>', { desc = '[O]cto [R]eview PR' })
+
+  -- In the review file panel, `<cr>` opens a file's diff but always moves
+  -- focus into the diff window (Layout:set_current_file has no stay-put
+  -- option). `o` opens the diff and keeps focus in the panel, so j/k
+  -- browsing isn't interrupted. Uses octo internals (undocumented API);
+  -- if an octo update breaks it, it fails loud on keypress, not silently.
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'octo_panel',
+    callback = function(ev)
+      vim.keymap.set('n', 'o', function()
+        local layout = require('octo.reviews').get_current_layout()
+        if layout and layout.file_panel:is_open() then
+          local file = layout.file_panel:get_file_at_cursor()
+          if file then layout:set_current_file(file) end
+          layout.file_panel:focus(true)
+        end
+      end, { buffer = ev.buf, desc = 'Open diff, stay in panel' })
+    end,
+  })
 end
 
 -- ============================================================


### PR DESCRIPTION
## Description

In octo's review file panel, `<cr>` opens the selected diff but unconditionally focuses the diff window — upstream `Layout:set_current_file` has no stay-put option. This adds a buffer-local `o` on `octo_panel` buffers that loads the diff then refocuses the panel, so j/k browsing continues uninterrupted. `<cr>` keeps its jump-in behavior for explicitly entering a file.

- Uses octo internals (`get_current_layout`, `set_current_file`, `file_panel:focus`) — undocumented API; breaks loud on keypress if upstream shifts, comment in-code says so

## Testing

- [x] `chezmoi diff --source .worktrees/feat-octo-panel-peek` shows only the expected changes
- [x] Rendered shell files pass `zsh -n` (n/a — lua; sandboxed headless boot: mapping registers on `octo_panel` filetype with correct desc)