### PR TITLE
feat(nvim): enable hybrid relative line numbers

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -109,11 +109,10 @@ do
   -- NOTE: You can change these options as you wish!
   --  For more options, you can see `:help option-list`
 
-  -- Make line numbers default
+  -- Hybrid line numbers: relative distances for jump counts, with the
+  -- absolute number shown on the cursor line ('number' + 'relativenumber').
   vim.o.number = true
-  -- You can also add relative line numbers, to help with jumping.
-  --  Experiment for yourself to see if you like it!
-  -- vim.o.relativenumber = true
+  vim.o.relativenumber = true
 
   -- Enable mouse mode, can be useful for resizing splits for example!
   vim.o.mouse = 'a'


### PR DESCRIPTION
## Description

Uncomment `vim.o.relativenumber` — with `number` already on, other lines show jump distance and the cursor line shows its absolute number.

## Testing

- [x] `chezmoi diff --source .worktrees/fix-relnumber` shows only the expected changes
- [x] Rendered shell files pass `zsh -n` (n/a — lua; headless boot confirms number+relativenumber both true)